### PR TITLE
Merge develop branch for upydevice 0.3.4 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fix
 - `WebSocketDevice` double unwanted `super().__init__` bug.
 - Load time in MacOS caused by bleak/corebluetooth, only if BleDevice
+- Allow mdns `.local` name in WebSecureREPL, (ssl checkhostname / auth server.)
 ### Added
 - Indicate websocket port in ip address as `ip:port` format
 ## [0.3.3] 2021-12-16

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [0.3.4] Unreleased Github Repo [develop]
-
+### Fix
+- `WebSocketDevice` double unwanted `super().__init__` bug.
 ## [0.3.3] 2021-12-16
 ### Added
 - `Host Name` in `__repr__` command device info

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [0.3.4] Unreleased Github Repo [develop]
+## [0.3.5] Unreleased Github Repo [develop]
+## [0.3.4] - 2022-03-04
 ### Fix
 - `WebSocketDevice` double unwanted `super().__init__` bug.
 - Load time in MacOS caused by bleak/corebluetooth, only if BleDevice
@@ -12,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WebSocketDevice` receive frame errors
 - `SerialDevice` follow command parsing errors
 - `BleDevice` follow command parsing errors
+- `is_reachable` method for `WebSocketDevice` if ip is mdns .local name
+- pipe option for `BleDevice` `wr_cmd` method.
 ### Added
 - Indicate websocket port in ip address as `ip:port` format
 - Allow `password:passphrase` format for `WebSocketDevice` password that sets ssl/auth

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.4] Unreleased Github Repo [develop]
 ### Fix
 - `WebSocketDevice` double unwanted `super().__init__` bug.
+- Load time in MacOS caused by bleak/corebluetooth, only if BleDevice
 ### Added
 - Indicate websocket port in ip address as `ip:port` format
 ## [0.3.3] 2021-12-16

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.4] Unreleased Github Repo [develop]
 ### Fix
 - `WebSocketDevice` double unwanted `super().__init__` bug.
+### Added
+- Indicate websocket port in ip address as `ip:port` format
 ## [0.3.3] 2021-12-16
 ### Added
 - `Host Name` in `__repr__` command device info

--- a/changelog.md
+++ b/changelog.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WebSocketDevice` double unwanted `super().__init__` bug.
 - Load time in MacOS caused by bleak/corebluetooth, only if BleDevice
 - Allow mdns `.local` name in WebSecureREPL, (ssl checkhostname / auth server.)
+- `WebSocketDevice` receive frame errors
+- `SerialDevice` follow command parsing errors
+- `BleDevice` follow command parsing errors
 ### Added
 - Indicate websocket port in ip address as `ip:port` format
+- Allow `password:passphrase` format for `WebSocketDevice` password that sets ssl/auth
+to `True` if present.
+- `address` property for all device types.
 ## [0.3.3] 2021-12-16
 ### Added
 - `Host Name` in `__repr__` command device info

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `password:passphrase` format for `WebSocketDevice` password that sets ssl/auth
 to `True` if present.
 - `address` property for all device types.
+- `flush_conn` for `BleDevice` for compatibility
 ## [0.3.3] 2021-12-16
 ### Added
 - `Host Name` in `__repr__` command device info

--- a/examples/pyqt-gui/pyqt_esp32_servo_slider.py
+++ b/examples/pyqt-gui/pyqt_esp32_servo_slider.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWidgets import QSlider, QHBoxLayout, QLabel
 from PyQt5.QtCore import Qt
 from upydevice import Device
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 _SERVO_PIN = 14
 

--- a/examples/pyqt-gui/pyqt_pyboard_interval_timer.py
+++ b/examples/pyqt-gui/pyqt_pyboard_interval_timer.py
@@ -10,6 +10,9 @@ from PyQt5.QtCore import (QObject, QRunnable, QThreadPool, pyqtSignal,
 from PyQt5.QtMultimedia import QSound
 import time
 from datetime import timedelta
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 # ICON_RED_LED_OFF = os.path.join(os.getcwd(), "icons/xsled-red-off.png")
 # ICON_RED_LED_ON = os.path.join(os.getcwd(), "icons/xsled-red-on.png")
 TIMER_FX = os.path.join(os.getcwd(), "sounds/beep-07a.wav")

--- a/examples/pyqt-gui/pyqt_pyboard_knob_leds_discrete.py
+++ b/examples/pyqt-gui/pyqt_pyboard_knob_leds_discrete.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWidgets import QHBoxLayout, QDial
 from PyQt5.QtCore import Qt
 from upydevice import Device
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 
 class KnobsLedpanel(QWidget):

--- a/examples/pyqt-gui/pyqt_pyboard_knobs_leds_cont.py
+++ b/examples/pyqt-gui/pyqt_pyboard_knobs_leds_cont.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWidgets import QHBoxLayout, QDial
 from PyQt5.QtCore import Qt
 from upydevice import Device
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 
 class KnobsLedpanel(QWidget):

--- a/examples/pyqt-gui/pyqt_pyboard_servo_key_controller.py
+++ b/examples/pyqt-gui/pyqt_pyboard_servo_key_controller.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWidgets import QHBoxLayout, QLabel
 from PyQt5.QtCore import Qt
 from upydevice import Device
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 
 class KeyController(QWidget):

--- a/examples/pyqt-gui/pyqt_pyboard_servo_slider.py
+++ b/examples/pyqt-gui/pyqt_pyboard_servo_slider.py
@@ -3,6 +3,9 @@ from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWidgets import QSlider, QHBoxLayout, QLabel
 from PyQt5.QtCore import Qt
 from upydevice import Device
+import os
+
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 
 class Slider(QWidget):

--- a/examples/pyqt-gui/pyqt_pyboard_switch_toggle_led.py
+++ b/examples/pyqt-gui/pyqt_pyboard_switch_toggle_led.py
@@ -7,7 +7,7 @@ import traceback
 from PyQt5.QtCore import (QObject, QRunnable, QThreadPool, pyqtSignal,
                           pyqtSlot)
 import time
-
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
 ICON_RED_LED_OFF = os.path.join(os.getcwd(), "icons/xsled-red-off.png")
 ICON_RED_LED_ON = os.path.join(os.getcwd(), "icons/xsled-red-on.png")
 
@@ -200,7 +200,7 @@ def toggle_led():
     led_widget.setWindowTitle("Upydevice Button Led Toggle")
     led_widget.show()
 
-    app.exec_()
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/examples/pyqt-gui/pyqt_toggle_led.py
+++ b/examples/pyqt-gui/pyqt_toggle_led.py
@@ -56,7 +56,7 @@ def main():
 
     # SerialDevice
     print("Connecting to device...")
-    mydev = Device("/dev/tty.SLAB_USBtoUART", init=True)
+    mydev = Device("/dev/cu.usbserial-016418E3", init=True)
 
     # # WebSocketDevice
     # mydev = Device('192.168.1.51', 'keyespw', init=True)
@@ -71,7 +71,7 @@ def main():
     led_widget.setWindowTitle("Upydevice Button Led Toggle")
     led_widget.show()
 
-    app.exec_()
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/examples/scripts/mpy_do_this.py
+++ b/examples/scripts/mpy_do_this.py
@@ -4,7 +4,7 @@ from upydevice import Device
 
 def main():
     # SerialDevice
-    mydev = Device('/dev/tty.SLAB_USBtoUART', init=True)
+    mydev = Device('/dev/tty.usbmodem3370377430372', init=True)
 
     # WebSocketDevice
     # mydev = Device('192.168.1.73', 'keyespw', init=True)
@@ -12,8 +12,8 @@ def main():
     # # BleDevice
     # mydev = Device('9998175F-9A91-4CA2-B5EA-482AFC3453B9', init=True)
 
-    mydev.wr_cmd('led.value(not led.value())')
-
+#    mydev.wr_cmd('led.value(not led.value())')
+    mydev.wr_cmd('led.toggle()')
     mydev.disconnect()
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 
 setup(name='upydevice',
-      version='0.3.3',
+      version='0.3.4',
       description='Python library to interface with wireless/serial MicroPython devices',
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/upydevice/__init__.py
+++ b/upydevice/__init__.py
@@ -148,4 +148,4 @@ To see more info read the DOCS at the github repo.
 
 from .upydevice import *
 name = 'upydevice'
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/upydevice/bledevice.py
+++ b/upydevice/bledevice.py
@@ -96,7 +96,7 @@ class BASE_BLE_DEVICE:
         self.is_notifying = False
         self.cmd_finished = True
         self.len_buffer = lenbuff
-        #
+        self.flush_conn = self.flush
         self.bytes_sent = 0
         self.buff = b''
         self.raw_buff = b''

--- a/upydevice/bledevice.py
+++ b/upydevice/bledevice.py
@@ -1348,8 +1348,8 @@ class AsyncBleDevice(BLE_DEVICE):
                         print(data, end='')
                     else:
                         for line in data.split('\n'):
-                            if line:
-                                self.pipe(line+'\n', std=self.pipe_mode)
+                            # if line:
+                            self.pipe(line+'\n', std=self.pipe_mode)
             else:
                 data = data.replace(b'\r', b'').replace(b'\r\n>>> ', b'').replace(
                     b'>>> ', b'').decode('utf-8', 'ignore')

--- a/upydevice/serialdevice.py
+++ b/upydevice/serialdevice.py
@@ -105,7 +105,8 @@ class BASE_SERIAL_DEVICE:
         self.output = None
         self.wr_cmd = self.cmd
         self.prompt = b'>>> '
-        self.dev_description, self.manufacturer, self._hwid = self._get_serial_port_data(serial_port)
+        self.dev_description, self.manufacturer, self._hwid = self._get_serial_port_data(
+            serial_port)
         self.serial = serial.Serial(serial_port, baudrate)
 
     def _get_serial_port_data(self, serialport):
@@ -141,9 +142,11 @@ class BASE_SERIAL_DEVICE:
         if self._traceback in self.buff:
             long_string = True
         if long_string:
-            self.response = self.buff.replace(b'\r', b'').replace(b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
+            self.response = self.buff.replace(b'\r', b'').replace(
+                b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
         else:
-            self.response = self.buff.replace(b'\r\n', b'').replace(b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
+            self.response = self.buff.replace(b'\r\n', b'').replace(
+                b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
         if not silent:
             if self.response != '\n' and self.response != '':
                 print(self.response)
@@ -172,12 +175,12 @@ class BASE_SERIAL_DEVICE:
         if not silent:
             print('Done!')
 
-    def kbi(self, silent=True, pipe=None):
+    def kbi(self, silent=True, pipe=None, long_string=False):
         if pipe is not None:
             self.wr_cmd(self._kbi, silent=silent)
             pipe(self.response, std='stderr')
         else:
-            self.cmd(self._kbi, silent=silent)
+            self.cmd(self._kbi, silent=silent, long_string=long_string)
 
     def banner(self, pipe=None):
         self.cmd(self._banner, silent=True, long_string=True)
@@ -248,8 +251,8 @@ class SERIAL_DEVICE(BASE_SERIAL_DEVICE):
         os.uname().machine, unique_id(), sys.implementation.name]"
         (self.dev_platform, self._release,
          self._version, self._machine, uuid, imp) = self.cmd(repr_cmd,
-                                                  silent=True,
-                                                  rtn_resp=True)
+                                                             silent=True,
+                                                             rtn_resp=True)
         vals = hexlify(uuid).decode()
         imp = imp[0].upper() + imp[1:]
         imp = imp.replace('p', 'P')
@@ -325,7 +328,8 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                     self.paste_cmd = ''
                     if pipe is None:
                         print('')  # print Traceback under ^C
-                        self.kbi(pipe=pipe, silent=False)  # KBI
+                        self.kbi(pipe=pipe, silent=False,
+                                 long_string=long_string)  # KBI
                     else:
                         self.kbi(pipe=pipe)  # KBI
                     time.sleep(0.2)
@@ -335,13 +339,16 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
         cmd_filt = bytes(cmd + '\r\n', 'utf-8')
         self.buff = self.buff.replace(cmd_filt, b'', 1)
         if dlog:
-            self.data_buff = self.buff.replace(b'\r', b'').replace(b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
+            self.data_buff = self.buff.replace(b'\r', b'').replace(
+                b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
         if self._traceback in self.buff:
             long_string = True
         if long_string:
-            self.response = self.buff.replace(b'\r', b'').replace(b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
+            self.response = self.buff.replace(b'\r', b'').replace(
+                b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
         else:
-            self.response = self.buff.replace(b'\r\n', b'').replace(b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
+            self.response = self.buff.replace(b'\r\n', b'').replace(
+                b'\r\n>>> ', b'').replace(b'>>> ', b'').decode()
         if not silent:
             if self.response != '\n' and self.response != '':
                 if pipe is None:
@@ -407,7 +414,7 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                 if pipe:
                     cmd_filt = bytes(inp + '\r\n', 'utf-8')
                     self.message = self.message.replace(cmd_filt, b'', 1)
-                msg = self.message.replace(b'\r', b'').decode()
+                msg = self.message.replace(b'\r', b'').decode('utf-8', 'ignore')
                 if 'cat' in inp:
                     if msg.endswith('>>> '):
                         msg = msg.replace('>>> ', '')
@@ -427,10 +434,12 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                                         if self._traceback.decode() in pipe_out:
                                             self._is_traceback = True
                                             # catch before traceback:
-                                            pipe_stdout = pipe_out.split(self._traceback.decode())[0]
+                                            pipe_stdout = pipe_out.split(
+                                                self._traceback.decode())[0]
                                             if pipe_stdout != '' and pipe_stdout != '\n':
                                                 pipe(pipe_stdout)
-                                            pipe_out = self._traceback.decode() + pipe_out.split(self._traceback.decode())[1]
+                                            pipe_out = self._traceback.decode(
+                                            ) + pipe_out.split(self._traceback.decode())[1]
                                         if self._is_traceback:
                                             pipe(pipe_out, std='stderr')
                                         else:
@@ -446,10 +455,12 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                                     if self._traceback.decode() in pipe_out:
                                         self._is_traceback = True
                                         # catch before traceback:
-                                        pipe_stdout = pipe_out.split(self._traceback.decode())[0]
+                                        pipe_stdout = pipe_out.split(
+                                            self._traceback.decode())[0]
                                         if pipe_stdout != '' and pipe_stdout != '\n':
                                             pipe(pipe_stdout)
-                                        pipe_out = self._traceback.decode() + pipe_out.split(self._traceback.decode())[1]
+                                        pipe_out = self._traceback.decode(
+                                        ) + pipe_out.split(self._traceback.decode())[1]
                                     if self._is_traceback:
                                         pipe(pipe_out, std='stderr')
                                     else:
@@ -465,10 +476,12 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                                 if self._traceback.decode() in pipe_out:
                                     self._is_traceback = True
                                     # catch before traceback:
-                                    pipe_stdout = pipe_out.split(self._traceback.decode())[0]
+                                    pipe_stdout = pipe_out.split(
+                                        self._traceback.decode())[0]
                                     if pipe_stdout != '' and pipe_stdout != '\n':
                                         pipe(pipe_stdout)
-                                    pipe_out = self._traceback.decode() + pipe_out.split(self._traceback.decode())[1]
+                                    pipe_out = self._traceback.decode(
+                                    ) + pipe_out.split(self._traceback.decode())[1]
                                 if self._is_traceback:
                                     pipe(pipe_out, std='stderr')
                                 else:
@@ -544,7 +557,8 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                 fs = int((1/time_out)*1000)
             if fs is not None:
                 temp_dict['fs'] = fs
-                temp_dict['ts'] = [i/temp_dict['fs'] for i in range(len(temp_dict[dvars[0]]))]
+                temp_dict['ts'] = [i/temp_dict['fs']
+                                   for i in range(len(temp_dict[dvars[0]]))]
             if units is not None:
                 temp_dict['u'] = units
             self.datalog = temp_dict

--- a/upydevice/serialdevice.py
+++ b/upydevice/serialdevice.py
@@ -409,7 +409,11 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                     if self.prompt in self.message:
                         break
             else:
-                self.message = self.serial.read_all()
+                self.message = b''
+                while b'\r\n' not in self.message:
+                    self.message += self.serial.read(1)
+                    if self.prompt in self.message:
+                        break
             self.buff += self.message
             self.raw_buff += self.message
             if self.message == b'':
@@ -420,7 +424,7 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                 if pipe:
                     cmd_filt = bytes(inp + '\r\n', 'utf-8')
                     self.message = self.message.replace(cmd_filt, b'', 1)
-                msg = self.message.replace(b'\r', b'').decode('utf-8', 'ignore')
+                msg = self.message.replace(b'\r', b'').decode('utf-8')
                 if 'cat' in inp:
                     if msg.endswith('>>> '):
                         msg = msg.replace('>>> ', '')

--- a/upydevice/serialdevice.py
+++ b/upydevice/serialdevice.py
@@ -275,6 +275,10 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
                                         desc_str,
                                         dev_str)
 
+    @property
+    def address(self):
+        return self.serial_port
+
     def flush_conn(self):
         flushed = 0
         while flushed < 2:

--- a/upydevice/serialdevice.py
+++ b/upydevice/serialdevice.py
@@ -267,13 +267,9 @@ class SERIAL_DEVICE(BASE_SERIAL_DEVICE):
         dev_str = '(MAC: {})'.format(self._mac)
         desc_str = '{}, Manufacturer: {}'.format(self.dev_description,
                                                  self.manufacturer)
-        return 'SerialDevice @ {}, Type: {}, \
-Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
-                                        self.dev_platform,
-                                        self.dev_class,
-                                        fw_str,
-                                        desc_str,
-                                        dev_str)
+        return (f'SerialDevice @ {self.serial_port}, Type: {self.dev_platform}, '
+                f'Class: {self.dev_class}\n'
+                f'Firmware: {fw_str}\n{desc_str}\n{dev_str}')
 
     @property
     def address(self):

--- a/upydevice/serialdevice.py
+++ b/upydevice/serialdevice.py
@@ -169,9 +169,15 @@ class BASE_SERIAL_DEVICE:
         if not hr:
             self.bytes_sent = self.serial.write(bytes(self._reset, 'utf-8'))
         else:
-            self.bytes_sent = self.serial.write(bytes(self._hreset, 'utf-8'))
+            try:
+                self.bytes_sent = self.serial.write(bytes(self._hreset, 'utf-8'))
+            except OSError:
+                pass
         time.sleep(0.5)
-        self.buff = self.serial.read_all()
+        try:
+            self.buff = self.serial.read_all()
+        except OSError:
+            pass
         if not silent:
             print('Done!')
 
@@ -409,7 +415,7 @@ Class: {}\nFirmware: {}\n{}\n{}'.format(self.serial_port,
             if self.message == b'':
                 pass
             else:
-                if self.message.startswith(b'\n'):
+                if self.message.startswith(b'\n') and 'ls(' not in inp:
                     self.message = self.message[1:]
                 if pipe:
                     cmd_filt = bytes(inp + '\r\n', 'utf-8')

--- a/upydevice/upydevice.py
+++ b/upydevice/upydevice.py
@@ -83,11 +83,6 @@ def Device(dev_address, password=None, **kargs):
             baudrt = fkargs.pop('baudrate')
         return SerialDevice(dev_address, baudrate=baudrt, **fkargs)
     if dev_type == 'WebSocketDevice':
-        if dev_address.endswith('.local'):
-            dev_address = socket.gethostbyname(dev_address)
-        elif '.local' in dev_address and ':' in dev_address:
-            hostname, port = dev_address.split(':')
-            dev_address = f"{socket.gethostbyname(hostname)}:{port}"
         return WebSocketDevice(dev_address, password, **kargs)
     if dev_type == 'BleDevice':
         from .bledevice import BleDevice

--- a/upydevice/upydevice.py
+++ b/upydevice/upydevice.py
@@ -26,7 +26,7 @@ from .serialdevice import *
 from .websocketdevice import *
 from .devgroup import *
 from .decorators import *
-from .bledevice import *
+# from .bledevice import *
 from .exceptions import *
 from ipaddress import ip_address
 import socket
@@ -90,6 +90,7 @@ def Device(dev_address, password=None, **kargs):
             dev_address = f"{socket.gethostbyname(hostname)}:{port}"
         return WebSocketDevice(dev_address, password, **kargs)
     if dev_type == 'BleDevice':
+        from .bledevice import BleDevice
         pop_args = ['ssl', 'auth', 'capath']
         fkargs = {k: v for k, v in kargs.items() if k not in pop_args}
         return BleDevice(dev_address, **fkargs)

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -158,16 +158,27 @@ class BASE_WS_DEVICE:
         self.connected = False
         self.repl_CONN = self.connected
         self._ssl = ssl
+        self._uriprotocol = 'ws'
+        if ssl:
+            self._uriprotocol = 'wss'
         if init:
             ip_now = None
-            if self.ip.endswith('.local'):
-                self.hostname = self.ip
-                self.hostname_mdns = self.ip
-                ip_now = socket.gethostbyname(self.hostname)
-
             if self.passphrase:
                 auth = True
                 ssl = True
+                self._uriprotocol = 'wss'
+                if self.port == 8266:
+                    self.port = 8833
+
+            if self.ip.endswith('.local'):
+                self.hostname = self.ip
+                self.hostname_mdns = self.ip
+                try:
+                    ip_now = socket.gethostbyname(self.hostname)
+                except socket.gaierror:
+                    raise DeviceNotFound(f"WebSocketDevice @ "
+                                         f"{self._uriprotocol}:"
+                                         f"//{self.ip}:{self.port} is not reachable")
 
             if not ssl:
                 self._uriprotocol = 'ws'
@@ -188,20 +199,30 @@ class BASE_WS_DEVICE:
                     self.ip = ip_now
                 self.repl_CONN = self.connected
             else:
-                raise DeviceNotFound(
-                    f"WebSocketDevice @ "
-                    f"{self._uriprotocol}://{self.ip}:{self.port} is not reachable")
+                raise DeviceNotFound(f"WebSocketDevice @ "
+                                     f"{self._uriprotocol}:"
+                                     f"//{self.ip}:{self.port} is not reachable")
 
     def open_wconn(self, ssl=False, auth=False, capath=CA_PATH):
         try:
             ip_now = None
-            if self.ip.endswith('.local'):
-                self.hostname = self.ip
-                self.hostname_mdns = self.ip
-                ip_now = socket.gethostbyname(self.hostname)
             if self.passphrase:
                 auth = True
                 ssl = True
+                self._uriprotocol = 'wss'
+                if self.port == 8266:
+                    self.port = 8833
+
+            if self.ip.endswith('.local'):
+                self.hostname = self.ip
+                self.hostname_mdns = self.ip
+                try:
+                    ip_now = socket.gethostbyname(self.hostname)
+                except socket.gaierror:
+                    raise DeviceNotFound(f"WebSocketDevice @ "
+                                         f"{self._uriprotocol}:"
+                                         f"//{self.ip}:{self.port} is not reachable")
+
             if not ssl:
                 self._uriprotocol = 'ws'
                 if self.port == 8833:
@@ -223,9 +244,9 @@ class BASE_WS_DEVICE:
                 if ip_now:
                     self.ip = ip_now
             else:
-                raise DeviceNotFound(
-                    f"WebSocketDevice @ "
-                    f"{self._uriprotocol}://{self.ip}:{self.port} is not reachable")
+                raise DeviceNotFound(f"WebSocketDevice @ "
+                                     f"{self._uriprotocol}:"
+                                     f"//{self.ip}:{self.port} is not reachable")
         except sslib.SSLError:
             raise sslib.SSLError
         except Exception as e:

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -519,7 +519,7 @@ class WS_DEVICE(BASE_WS_DEVICE):
                 try:
                     self.follow_output(cmd, pipe=pipe, multiline=multiline,
                                        silent=silent_pipe)
-                except KeyboardInterrupt as e:
+                except KeyboardInterrupt:
                     # time.sleep(0.2)
                     self.paste_cmd = ''
                     if pipe is None:

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -246,6 +246,10 @@ class BASE_WS_DEVICE:
         self.close_wconn()
 
     @property
+    def address(self):
+        return self.ip
+
+    @property
     def debug(self):
         return self._debug
 

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -626,8 +626,11 @@ class WS_DEVICE(BASE_WS_DEVICE):
                 break
         self.paste_cmd = ''
 
-    def is_reachable(self, n_tries=2, max_loss=1, debug=False, timeout=2):
-        ping_cmd_str = 'ping -c {} {} -t {}'.format(n_tries, self.ip, timeout)
+    def is_reachable(self, n_tries=2, max_loss=1, debug=False, timeout=2, zt=False):
+        if zt:
+            ping_cmd_str = f'ssh {zt["fwd"]} ping -c {n_tries} {zt["dev"]} -t {timeout}'
+        else:
+            ping_cmd_str = 'ping -c {} {} -t {}'.format(n_tries, self.ip, timeout)
         ping_cmd = shlex.split(ping_cmd_str)
         timeouts = 0
         down_kw = ['Unreachable', 'down', 'timeout']

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -790,12 +790,15 @@ class WS_DEVICE(BASE_WS_DEVICE):
             time.sleep(0.1)
             self.write(line+'\n')
         if flush:
-            while long_command.split('\n')[-1] not in paste_echo:
-                fin, op, data = self.ws.read_frame()
-                paste_echo = data.decode('utf-8', 'ignore')
-            self.flush_conn()
-            while self.ws_readable():
-                time.sleep(0.1)
+            try:
+                while long_command.split('\n')[-1] not in paste_echo:
+                    fin, op, data = self.ws.read_frame()
+                    paste_echo = data.decode('utf-8', 'ignore')
+                self.flush_conn()
+                while self.ws_readable():
+                    time.sleep(0.1)
+            except socket.timeout:
+                pass
 
     def get_datalog(self, dvars=None, fs=None, time_out=None, units=None):
         self.datalog = []

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -752,4 +752,3 @@ class WS_DEVICE(BASE_WS_DEVICE):
 class WebSocketDevice(WS_DEVICE):
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
-        super().__init__(*args, **kargs)

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -120,7 +120,11 @@ class BASE_WS_DEVICE:
         self.ws = None
         self.ip = target
         self.pswd = password
-        self.port = 8266
+        if ':' in target:
+            self.ip, self.port = target.split(':')
+            self.port = int(self.port)
+        else:
+            self.port = 8266
         self.bytes_sent = 0
         self.buff = b''
         self.raw_buff = b''
@@ -143,7 +147,8 @@ class BASE_WS_DEVICE:
                 self.ws = wsclient.connect(
                     'ws://{}:{}'.format(self.ip, self.port), self.pswd)
             else:
-                self.port = 8833
+                if self.port == 8266:
+                    self.port = 8833
                 self._uriprotocol = 'wss'
                 self.ws = wsclient.connect(
                     'wss://{}:{}'.format(self.ip, self.port), self.pswd,
@@ -163,7 +168,8 @@ class BASE_WS_DEVICE:
                     'ws://{}:{}'.format(self.ip, self.port), self.pswd)
             else:
                 self._uriprotocol = 'wss'
-                self.port = 8833
+                if self.port == 8266:
+                    self.port = 8833
                 self.ws = wsclient.connect(
                     'wss://{}:{}'.format(self.ip, self.port),
                     self.pswd, auth=auth, capath=capath)

--- a/upydevice/websocketdevice.py
+++ b/upydevice/websocketdevice.py
@@ -745,10 +745,13 @@ class WS_DEVICE(BASE_WS_DEVICE):
         if zt:
             ping_cmd_str = f'ssh {zt["fwd"]} ping -c {n_tries} {zt["dev"]} -t {timeout}'
         else:
-            ping_cmd_str = 'ping -c {} {} -t {}'.format(n_tries, self.ip, timeout)
+            if self.ip.endswith('.local'):
+                ping_cmd_str = 'ping -c {} {} '.format(n_tries, self.ip)
+            else:
+                ping_cmd_str = 'ping -c {} {} -t {}'.format(n_tries, self.ip, timeout)
         ping_cmd = shlex.split(ping_cmd_str)
         timeouts = 0
-        down_kw = ['Unreachable', 'down', 'timeout']
+        down_kw = ['Unreachable', 'down', 'timeout', 'Unknown']
         try:
             proc = subprocess.Popen(
                 ping_cmd, stdout=subprocess.PIPE,

--- a/upydevice/wsclient.py
+++ b/upydevice/wsclient.py
@@ -35,6 +35,7 @@ import random
 import ssl
 import os
 import io
+import getpass
 from upydevice.wsprotocol import Websocket, urlparse, URI
 
 
@@ -67,15 +68,15 @@ def load_cert_from_hostname(path, hostname):
         with io.open(os.path.join(path, cert), 'rb') as certfile:
             cert_datafile += certfile.read()
             if hostname.encode() in cert_datafile:
-                key = os.path.join(path, cert.replace('.der', '.pem').replace('certificate',
-                                                                              'key'))
+                _key = cert.replace('certificate', 'key').replace('.der', '.pem')
+                key = os.path.join(path, _key)
                 cert = os.path.join(path, cert.replace('.der', '.pem'))
                 return key, cert
             else:
                 cert_datafile = b''
 
 
-def connect(uri, password, silent=True, auth=False, capath=None):
+def connect(uri, password, silent=True, auth=False, capath=None, passphrase=None):
     """
     Connect a websocket.
     """
@@ -106,9 +107,24 @@ def connect(uri, password, silent=True, auth=False, capath=None):
             context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             context.load_verify_locations(cadata=load_custom_CA_data(capath))
             # load cert from hostname
-            # key, cert = load_cert_from_hostname(capath, hostname)
+            key, cert = load_cert_from_hostname(capath, hostname)
             # if cert:
-            # context.load_cert_chain(cert, key)
+            if not passphrase:
+                while True:
+                    try:
+                        passphrase = getpass.getpass(f'Enter passphrase for '
+                                                     f'{urlparse(hostname).hostname} '
+                                                     f'key: ',
+                                                     stream=None)
+                        context.load_cert_chain(cert, key, password=passphrase)
+                        break
+                    except (OSError, ssl.SSLError):
+                        print('Invalid passhprase, try again...')
+                    except KeyboardInterrupt:
+                        print('KeyboardInterrupt')
+                        break
+            else:
+                context.load_cert_chain(cert, key, password=passphrase)
             context.set_ciphers('ECDHE-ECDSA-AES128-CCM8')
             sock = context.wrap_socket(sock, server_hostname=hostname)
         else:

--- a/upydevice/wsclient.py
+++ b/upydevice/wsclient.py
@@ -35,9 +35,8 @@ import random
 import ssl
 import os
 import io
+from upydevice.wsprotocol import Websocket, urlparse, URI
 
-from upydevice.wsprotocol import Websocket, urlparse
-from upydevice.exceptions import DeviceNotFound
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -50,13 +49,30 @@ class WebsocketClient(Websocket):
 
 
 def load_custom_CA_data(path):
-    certificates = [cert for cert in os.listdir(path) if 'certificate' in cert and cert.endswith('.pem')]
+    certificates = [cert for cert in os.listdir(
+        path) if 'certificate' in cert and cert.endswith('.pem')]
     cert_datafile = ''
     for cert in certificates:
-        with io.open(path+'/{}'.format(cert), 'r') as certfile:
+        with io.open(os.path.join(path, cert), 'r') as certfile:
             cert_datafile += certfile.read()
             cert_datafile += '\n\n'
     return cert_datafile
+
+
+def load_cert_from_hostname(path, hostname):
+    certificates = [cert for cert in os.listdir(
+        path) if 'certificate' in cert and cert.endswith('.der')]
+    cert_datafile = b''
+    for cert in certificates:
+        with io.open(os.path.join(path, cert), 'rb') as certfile:
+            cert_datafile += certfile.read()
+            if hostname.encode() in cert_datafile:
+                key = os.path.join(path, cert.replace('.der', '.pem').replace('certificate',
+                                                                              'key'))
+                cert = os.path.join(path, cert.replace('.der', '.pem'))
+                return key, cert
+            else:
+                cert_datafile = b''
 
 
 def connect(uri, password, silent=True, auth=False, capath=None):
@@ -65,6 +81,15 @@ def connect(uri, password, silent=True, auth=False, capath=None):
     """
     hostname = uri
     uri = urlparse(uri)
+    try:
+        if '.local' in uri.hostname:
+
+            uri = URI(uri.protocol, socket.gethostbyname(uri.hostname),
+                      uri.port, uri.path)
+
+    except Exception as e:
+        print(e)
+        return
     assert uri
 
     if __debug__:
@@ -80,6 +105,10 @@ def connect(uri, password, silent=True, auth=False, capath=None):
         if auth:
             context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             context.load_verify_locations(cadata=load_custom_CA_data(capath))
+            # load cert from hostname
+            # key, cert = load_cert_from_hostname(capath, hostname)
+            # if cert:
+            # context.load_cert_chain(cert, key)
             context.set_ciphers('ECDHE-ECDSA-AES128-CCM8')
             sock = context.wrap_socket(sock, server_hostname=hostname)
         else:
@@ -100,7 +129,6 @@ def connect(uri, password, silent=True, auth=False, capath=None):
         except socket.timeout as e:
             print(e)
             return
-
 
     def send_header(header):
         # if __debug__: LOGGER.debug(str(header), *args)


### PR DESCRIPTION
Merge develop branch for upydevice 0.3.4 release

### Fix
- `WebSocketDevice` double unwanted `super().__init__` bug.
- Load time in MacOS caused by bleak/corebluetooth, only if BleDevice
- Allow mdns `.local` name in WebSecureREPL, (ssl checkhostname / auth server.)
- `WebSocketDevice` receive frame errors
- `SerialDevice` follow command parsing errors
- `BleDevice` follow command parsing errors
- `is_reachable` method for `WebSocketDevice` if ip is mdns .local name
- pipe option for `BleDevice` `wr_cmd` method.
### Added
- Indicate websocket port in ip address as `ip:port` format
- Allow `password:passphrase` format for `WebSocketDevice` password that sets ssl/auth
to `True` if present.
- `address` property for all device types.
- `flush_conn` for `BleDevice` for compatibility